### PR TITLE
Fix PYQT6 compatiblity from issue #22830

### DIFF
--- a/spyder/api/widgets/dialogs.py
+++ b/spyder/api/widgets/dialogs.py
@@ -10,7 +10,7 @@ Spyder dialog widgets.
 
 # Third-party imports
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QIcon
+from qtpy.QtGui import QIcon, PYQT5, PYSIDE2
 from qtpy.QtWidgets import QDialogButtonBox, QProxyStyle, QStyle
 
 # Local imports
@@ -26,7 +26,10 @@ class _SpyderButtonsProxyStyle(QProxyStyle):
             # platforms. We selected that layout because Windows is our most
             # popular platform.
             # Solution found in https://stackoverflow.com/a/35907926/438386
-            return QDialogButtonBox.WinLayout
+            if PYQT5 or PYSIDE2:
+                return QDialogButtonBox.WinLayout
+            else:    # PYQT6: need to return an int, not enum
+                return QDialogButtonBox.WinLayout.value
 
         return super().styleHint(hint, option, widget, return_data)
 


### PR DESCRIPTION
invalid result from _SpyderButtonsProxyStyle.styleHint(), 'ButtonLayout' object cannot be interpreted as an integer return int instead of enum

<!--- Make sure to read the Contributing Guidelines:                   --->
<!--- https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md --->
<!--- and follow PEP 8, PEP 257 and Spyder's code style:               --->
<!--- https://github.com/spyder-ide/spyder/wiki/Dev:-Coding-Style      --->

## Description of Changes


* [X ] Wrote at least one-line docstrings (for any new functions)
* [ ] Added unit test(s) covering the changes (if testable)
<!--- Remember that an image/animation is worth a thousand words! --->
* [ ] Included a screenshot or animation (if affecting the UI, see [Licecap](https://www.cockos.com/licecap/))


<!--- Explain what you've done and why --->
now works in PYQT5 or PYQT6



### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

Fixes #


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
fxjaeckel

<!--- Thanks for your help making Spyder better for everyone! --->
